### PR TITLE
Update the default value of JAVA_BINARY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: $(BUILD) $(BUILD)/zmmailboxdmgr $(BUILD)/zmmailboxdmgr.unrestricted
 $(BUILD):
 	mkdir $(BUILD)
 
-JAVA_BINARY ?= /opt/zimbra/java/bin/java
+JAVA_BINARY ?= /opt/zimbra/common/bin/java
 MAILBOXD_MANAGER_PIDFILE ?= /opt/zimbra/log/zmmailboxd_manager.pid
 MAILBOXD_MANAGER_DEPRECATED_PIDFILE ?= /opt/zimbra/log/zmmailboxd.pid
 MAILBOXD_JAVA_PIDFILE ?= /opt/zimbra/log/zmmailboxd_java.pid


### PR DESCRIPTION
The location of the Zimbra Java binary changed from /opt/zimbra/java/bin/java
to /opt/zimbra/common/bin/java.  So when building zmmailboxdmgr you have to
provide the new path to the Makefile to make it work.  There is an override to
do so in zm-build but since the Java binary will probably stay where it is
now, this patch changes the default path as well.