### PR TITLE
ZCS-6714 Removing endorsed dir to support JDK 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.project

--- a/src/launcher/zmmailboxdmgr.c
+++ b/src/launcher/zmmailboxdmgr.c
@@ -590,7 +590,6 @@ Start(int nextArg, int argc, char *argv[])
    
     AddArgFmt("-Djava.io.tmpdir=%s/work", JETTY_BASE);
     AddArgFmt("-Djava.library.path=%s", ZIMBRA_LIB);
-    AddArgFmt("-Djava.endorsed.dirs=%s/common/endorsed", JETTY_BASE);
     AddArgFmt("-Dzimbra.config=%s", ZIMBRA_CONFIG);
 
     /* We don't want these things being passed in from command line */


### PR DESCRIPTION
Modified zmmailboxdmgr.c. Removed endorsed dir from command line options.
Build zmmailboxdmgr
Installed on ZCS with JDK 11 verified ZCS process starts without any issue
