### PR TITLE
zcs-6542:jetty upgrade

### DIFF
--- a/src/launcher/zmmailboxdmgr.c
+++ b/src/launcher/zmmailboxdmgr.c
@@ -602,7 +602,7 @@ Start(int nextArg, int argc, char *argv[])
     AddArgFmt("-DSTART=%s/etc/start.config", JETTY_BASE);
     AddArg("-jar");
     AddArgFmt("%s/start.jar", JETTY_HOME);
-    AddArg("--module=zimbra,server,servlet,servlets,jsp,jstl,jmx,resources,websocket,ext,plus,rewrite,monitor,continuation,webapp,setuid");
+    AddArg("--module=zimbra,server,servlet,servlets,jsp,jstl,jmx,resources,websocket,ext,plus,rewrite,continuation,webapp,setuid");
     AddArgFmt("jetty.home=%s", JETTY_HOME);
     AddArgFmt("jetty.base=%s", JETTY_BASE);
     AddArgFmt("%s/etc/jetty.xml", JETTY_BASE);


### PR DESCRIPTION
Upgraded to jetty 9.4.15.xxx which does not support monitor module. so removed it.