### PR TITLE
Bugfix/zcs 6542 Jetty upgrade

### DIFF
--- a/src/launcher/zmmailboxdmgr.c
+++ b/src/launcher/zmmailboxdmgr.c
@@ -602,7 +602,7 @@ Start(int nextArg, int argc, char *argv[])
     AddArgFmt("-DSTART=%s/etc/start.config", JETTY_BASE);
     AddArg("-jar");
     AddArgFmt("%s/start.jar", JETTY_HOME);
-    AddArg("--module=zimbra,server,servlet,servlets,jsp,jstl,jmx,resources,websocket,ext,plus,rewrite,continuation,webapp,setuid");
+    AddArg("--module=zimbra,server,mail,servlet,servlets,jsp,jstl,jmx,resources,websocket,ext,plus,rewrite,continuation,webapp,setuid");
     AddArgFmt("jetty.home=%s", JETTY_HOME);
     AddArgFmt("jetty.base=%s", JETTY_BASE);
     AddArgFmt("%s/etc/jetty.xml", JETTY_BASE);


### PR DESCRIPTION
issue : mail module was not recognised by jetty while starting up.

fix : added mail module to --module option of jetty. 

Linked PR:
https://github.com/Zimbra/zm-jetty-conf/pull/5