### PR TITLE
ZCS-11457: zimlet path fix for jetty symlink failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ GC_OUTFILE ?= /opt/zimbra/log/gc.log
 ZIMBRA_LIB ?= /opt/zimbra/lib
 ZIMBRA_USER ?= zimbra
 ZIMBRA_CONFIG ?= /opt/zimbra/conf/localconfig.xml
+JETTY_ZIMLET_BASE ?= /opt/zimbra/jetty_base
 
 LAUNCHER_CFLAGS = \
 	-DJAVA_BINARY='"$(JAVA_BINARY)"' \
@@ -39,6 +40,7 @@ LAUNCHER_CFLAGS = \
 	-DGC_OUTFILE='"$(GC_OUTFILE)"' \
 	-DZIMBRA_LIB='"$(ZIMBRA_LIB)"' \
 	-DZIMBRA_USER='"$(ZIMBRA_USER)"' \
+	-DJETTY_ZIMLET_BASE='"$(JETTY_ZIMLET_BASE)"' \
 	-DZIMBRA_CONFIG='"$(ZIMBRA_CONFIG)"'
 
 ifeq ($(ZIMBRA_USE_TOMCAT), 1)

--- a/src/launcher/zmmailboxdmgr.c
+++ b/src/launcher/zmmailboxdmgr.c
@@ -599,12 +599,14 @@ Start(int nextArg, int argc, char *argv[])
     /* We don't want these things being passed in from command line */
     AddArgFmt("-Djetty.base=%s", JETTY_BASE);
     AddArgFmt("-Djetty.home=%s", JETTY_HOME);
+    AddArgFmt("-Djetty.zimlet.base=%s", JETTY_ZIMLET_BASE);
     AddArgFmt("-DSTART=%s/etc/start.config", JETTY_BASE);
     AddArg("-jar");
     AddArgFmt("%s/start.jar", JETTY_HOME);
     AddArg("--module=zimbra,server,mail,servlet,servlets,jsp,jstl,jmx,resources,websocket,ext,plus,rewrite,continuation,webapp,setuid");
     AddArgFmt("jetty.home=%s", JETTY_HOME);
     AddArgFmt("jetty.base=%s", JETTY_BASE);
+    AddArgFmt("jetty.zimlet.base=%s", JETTY_ZIMLET_BASE);
     AddArgFmt("%s/etc/jetty.xml", JETTY_BASE);
 
     if (Verbose) {


### PR DESCRIPTION
**Problem :** Jetty-9.4.46.v20220331-2 not able to get resolve path `/opt/zimbra/mailboxd` which is symlink to `/opt/zimbra/jetty_base`

`lrwxrwxrwx  1 zimbra zimbra   10 Apr 19 07:05 mailboxd -> jetty_base`

Added new parameter `jetty.zimlet.base` which is points to `/opt/zimbra/jetty_base` this will be used by jetty xml file `/opt/zimbra/jetty_base/etc/jetty.xml.in`

Related PR: https://github.com/Zimbra/zm-jetty-conf/pull/20