### PR TITLE
ZBUG-2991:remove jetty.zimlet.base path from mailbox process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ GC_OUTFILE ?= /opt/zimbra/log/gc.log
 ZIMBRA_LIB ?= /opt/zimbra/lib
 ZIMBRA_USER ?= zimbra
 ZIMBRA_CONFIG ?= /opt/zimbra/conf/localconfig.xml
-JETTY_ZIMLET_BASE ?= /opt/zimbra/jetty_base
 
 LAUNCHER_CFLAGS = \
 	-DJAVA_BINARY='"$(JAVA_BINARY)"' \
@@ -40,7 +39,6 @@ LAUNCHER_CFLAGS = \
 	-DGC_OUTFILE='"$(GC_OUTFILE)"' \
 	-DZIMBRA_LIB='"$(ZIMBRA_LIB)"' \
 	-DZIMBRA_USER='"$(ZIMBRA_USER)"' \
-	-DJETTY_ZIMLET_BASE='"$(JETTY_ZIMLET_BASE)"' \
 	-DZIMBRA_CONFIG='"$(ZIMBRA_CONFIG)"'
 
 ifeq ($(ZIMBRA_USE_TOMCAT), 1)

--- a/src/launcher/zmmailboxdmgr.c
+++ b/src/launcher/zmmailboxdmgr.c
@@ -599,14 +599,12 @@ Start(int nextArg, int argc, char *argv[])
     /* We don't want these things being passed in from command line */
     AddArgFmt("-Djetty.base=%s", JETTY_BASE);
     AddArgFmt("-Djetty.home=%s", JETTY_HOME);
-    AddArgFmt("-Djetty.zimlet.base=%s", JETTY_ZIMLET_BASE);
     AddArgFmt("-DSTART=%s/etc/start.config", JETTY_BASE);
     AddArg("-jar");
     AddArgFmt("%s/start.jar", JETTY_HOME);
     AddArg("--module=zimbra,server,mail,servlet,servlets,jsp,jstl,jmx,resources,websocket,ext,plus,rewrite,continuation,webapp,setuid");
     AddArgFmt("jetty.home=%s", JETTY_HOME);
     AddArgFmt("jetty.base=%s", JETTY_BASE);
-    AddArgFmt("jetty.zimlet.base=%s", JETTY_ZIMLET_BASE);
     AddArgFmt("%s/etc/jetty.xml", JETTY_BASE);
 
     if (Verbose) {


### PR DESCRIPTION
We have introduced jetty.zimlet.base as part of https://github.com/Zimbra/zm-launcher/pull/11
But now we are going to use current working directory of jetty process path for zimlets-deployed directory, so removing `jetty.zimlet.base` property from mailbox process as this is not required for now.
Related PR : https://github.com/Zimbra/zm-jetty-conf/pull/23